### PR TITLE
refactor: eliminar supplier_id redundante de products, trazabilidad vive en lotes

### DIFF
--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -107,7 +107,7 @@ class SupplierController extends Controller
      */
     public function destroy(Supplier $supplier)
     {
-        $hasProducts = $supplier->products()->exists() || $supplier->productsManyToMany()->exists();
+        $hasProducts = $supplier->products()->exists();
         $hasPurchases = $supplier->productPurchases()->exists();
 
         if ($hasProducts || $hasPurchases) {

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -11,7 +11,7 @@ class Product extends Model
     protected $fillable = [
         'name',
         'category',
-        'supplier_id',
+
         'purchase_price',
         'sale_price',
         'stock',
@@ -19,9 +19,16 @@ class Product extends Model
         'upc',
     ];
 
-    public function supplier()
+    /**
+     * Get the last supplier from the most recent batch.
+     */
+    public function lastSupplier()
     {
-        return $this->belongsTo(Supplier::class);
+        return $this->batches()
+            ->latest('created_at')
+            ->with('supplier')
+            ->first()
+            ?->supplier;
     }
 
     /**
@@ -47,7 +54,7 @@ class Product extends Model
             'movement_type' => 'purchase',
             'quantity' => $quantity,
             'unit_price' => $unitPrice ?? $this->purchase_price,
-            'supplier_id' => $supplierId ?? $this->supplier_id,
+            'supplier_id' => $supplierId,
             'reference' => $reference,
             'movement_date' => now(),
         ]);

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -19,12 +19,10 @@ class Supplier extends Model
         return $query->where('active', true);
     }
 
+    /**
+     * Products associated through pivot table
+     */
     public function products()
-    {
-        return $this->hasMany(Product::class);
-    }
-
-    public function productsManyToMany()
     {
         return $this->belongsToMany(Product::class);
     }

--- a/database/migrations/2026_02_04_182717_create_products_table.php
+++ b/database/migrations/2026_02_04_182717_create_products_table.php
@@ -15,10 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('category');
-            $table->foreignId('supplier_id')
-                ->nullable()
-                ->constrained()
-                ->restrictOnDelete(); // Evitar productos huérfanos si se borra proveedor
+
             $table->decimal('purchase_price', 10, 2); // Precio de compra
             $table->decimal('sale_price', 10, 2); // Precio de venta
             $table->unsignedInteger('stock');

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -67,18 +67,31 @@
         <div class="space-y-8">
             <x-card>
                 <x-slot name="header">
-                    <h3 class="font-bold text-slate-900">Proveedor Asignado</h3>
+                    <h3 class="font-bold text-slate-900">Proveedores</h3>
                 </x-slot>
-                <div class="flex items-start gap-4">
-                    <div class="h-12 w-12 rounded-xl bg-slate-100 flex items-center justify-center flex-shrink-0">
-                        <i data-lucide="truck" class="h-6 w-6 text-slate-600"></i>
+
+                @php $lastSupplier = $product->lastSupplier(); @endphp
+
+                @if($product->suppliers->isNotEmpty())
+                    <div class="space-y-3">
+                        @foreach($product->suppliers as $supplier)
+                            <div class="flex items-center gap-3 p-3 rounded-xl {{ $lastSupplier && $lastSupplier->id === $supplier->id ? 'bg-blue-50 border border-blue-200' : 'bg-slate-50' }}">
+                                <div class="h-10 w-10 rounded-lg {{ $lastSupplier && $lastSupplier->id === $supplier->id ? 'bg-blue-100' : 'bg-slate-100' }} flex items-center justify-center flex-shrink-0">
+                                    <i data-lucide="truck" class="h-5 w-5 {{ $lastSupplier && $lastSupplier->id === $supplier->id ? 'text-blue-600' : 'text-slate-500' }}"></i>
+                                </div>
+                                <div class="flex-1">
+                                    <p class="font-bold text-slate-900">{{ $supplier->name }}</p>
+                                    @if($lastSupplier && $lastSupplier->id === $supplier->id)
+                                        <span class="text-xs text-blue-600 font-semibold">Último proveedor</span>
+                                    @endif
+                                </div>
+                                <a href="{{ route('suppliers.show', $supplier) }}" class="text-sm text-blue-600 hover:underline">Ver perfil</a>
+                            </div>
+                        @endforeach
                     </div>
-                    <div>
-                        <p class="font-bold text-slate-900">{{ $product->supplier->name ?? 'Sin proveedor' }}</p>
-                        <p class="text-xs text-slate-500">Última compra: {{ $product->updated_at->format('d/m/Y') }}</p>
-                        <a href="{{ route('suppliers.show', $product->supplier_id) }}" class="mt-2 inline-block text-sm text-blue-600 hover:underline">Ver perfil del proveedor</a>
-                    </div>
-                </div>
+                @else
+                    <p class="text-sm text-slate-500">Sin proveedores asignados.</p>
+                @endif
             </x-card>
         </div>
     </div>


### PR DESCRIPTION
refactor: remove redundant supplier_id from products table
Supplier traceability now lives exclusively in batches (FIFO).
- Remove supplier_id column from products migration
- Replace belongsTo with lastSupplier() helper method
- Consolidate Supplier model to use only belongsToMany
- Update product show view to display all associated suppliers